### PR TITLE
Change the endpoint for the Portal Aspect from /portal/suit/ to /portal/app/

### DIFF
--- a/public_html/index.html.template
+++ b/public_html/index.html.template
@@ -45,7 +45,7 @@
 
   <div class="col-md-3" style=" text-align: center">
   <h4> Portal Aspect  </h4>
-  <a href="/portal/suit/" ><img src="static/portal_logo.png" class="img-circle" alt="portal" width="100px"></a>
+  <a href="/portal/app/" ><img src="static/portal_logo.png" class="img-circle" alt="portal" width="100px"></a>
 
   </div>
 


### PR DESCRIPTION
This is part of a general attempt to keep "suit" out of the public presentation of the LSP.  (It's an organizational name within DM; we want to keep the external focus on "Portal Aspect" to avoid user confusion.)